### PR TITLE
feat: serialization strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ pnpm dev         # Starts development server at http://localhost:5173
 
 ## Acknowledgments
 
-We would like to thank all contributors, researchers, and supporters who have helped make Trinity possible. Special thanks to Vivek and the Cursive team for originally imagining the scheme, the research team behind the Laconic OT paper and their implementation, and Nakul for his help in integrating secure garbling. Additionally, we extend our gratitude to the authors of the mpz garbling framework and the PSE Halo2 team for their foundational work and inspiration.
+We would like to thank all contributors, researchers, and supporters who have helped make Trinity possible. Special thanks to @RiverRuby and the [Cursive team](https://github.com/cursive-team) for originally designing the scheme, the research team behind the Laconic OT paper and their implementation. Thanks Nakul and Breachy for their help in integrating secure garbling and Halo2 LOT. Additionally, we extend our gratitude to the authors of the mpz garbling framework and the PSE Halo2 team for their foundational work and inspiration.

--- a/halo2_lot/Cargo.toml
+++ b/halo2_lot/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 halo2_proofs = { git = "https://github.com/Meyanis95/halo2.git", branch = "main", features = ["derive_serde"] }
 halo2_middleware = { git = "https://github.com/Meyanis95/halo2.git", branch = "main" }
 halo2_backend = { git = "https://github.com/Meyanis95/halo2.git", package = "halo2_backend", branch = "main" }
-halo2curves = { git = "https://github.com/Meyanis95/halo2curves.git", branch = "main" }
+halo2curves = { git = "https://github.com/Meyanis95/halo2curves.git", branch = "main", features = ["derive_serde"] }
 rand = "0.8"
 blake3 = "1.5.5"
 bincode = "1.3.3"
@@ -19,4 +19,4 @@ halo2_backend = { git = "https://github.com/Meyanis95/halo2.git", package = "hal
 halo2_middleware = { git = "https://github.com/Meyanis95/halo2.git", branch = "main" }
 
 [patch.crates-io]
-halo2curves = { git = "https://github.com/Meyanis95/halo2curves.git", branch = "main" }
+halo2curves = { git = "https://github.com/Meyanis95/halo2curves.git", branch = "main", features = ["derive_serde"] }

--- a/halo2_lot/src/circuits.rs
+++ b/halo2_lot/src/circuits.rs
@@ -139,7 +139,6 @@ pub fn kzg_commitment_with_halo2_proof(
 
     // Finalize and serialize the proof
     let proof = proof_transcript.finalize();
-    println!("Proof created successfully!");
 
     // Verify the proof
     let mut verifier_transcript =
@@ -162,10 +161,6 @@ pub fn kzg_commitment_with_halo2_proof(
 
     // Extract the bitvector as advice column commitment from Halo2 proof
     let halo2_commitment = commitments[0];
-    println!(
-        "Halo2 Commitment to the bitvector column: {:?}",
-        halo2_commitment
-    );
 
     Ok(CircuitOutput {
         commitment: halo2_commitment,

--- a/halo2_lot/src/laconic_ot.rs
+++ b/halo2_lot/src/laconic_ot.rs
@@ -46,7 +46,7 @@ pub struct Msg {
     pub h: [(G2Affine, [u8; MSG_SIZE]); 2],
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SerializableMsg {
     pub h: [(Vec<u8>, [u8; MSG_SIZE]); 2],
 }

--- a/halo2_lot/src/lib.rs
+++ b/halo2_lot/src/lib.rs
@@ -8,4 +8,4 @@ pub use crate::poly_op::{
 };
 pub use circuits::kzg_commitment_with_halo2_proof;
 pub use laconic_ot::{Choice, Com, LaconicOTRecv, LaconicOTSender, Msg};
-pub use params::Halo2Params;
+pub use params::{Halo2Params, LaconicParams, SerializableLaconicParams};

--- a/halo2_lot/src/params.rs
+++ b/halo2_lot/src/params.rs
@@ -1,5 +1,9 @@
 use halo2_proofs::poly::{kzg::commitment::ParamsKZG, EvaluationDomain};
-use halo2curves::bn256::{Bn256, Fr};
+use halo2curves::{
+    bn256::{Bn256, Fr, G1Affine, G2Affine},
+    serde::SerdeObject,
+};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone)]
 pub struct Halo2Params {
@@ -8,11 +12,144 @@ pub struct Halo2Params {
     pub params: ParamsKZG<Bn256>,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct SerializableHalo2Params {
+    pub k: u32,
+    pub g0: Vec<u8>,
+    pub g2: Vec<u8>,
+    pub s_g2: Vec<u8>,
+}
+
 impl Halo2Params {
     pub fn setup<R: rand::Rng>(rng: &mut R, k: usize) -> Result<Halo2Params, ()> {
         let params: ParamsKZG<Bn256> = ParamsKZG::setup(k as u32, rng);
         let domain = EvaluationDomain::new(1, k as u32);
 
         Ok(Halo2Params { k, domain, params })
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let serializable = SerializableHalo2Params {
+            k: self.k as u32,
+            g0: self.params.g[0].to_raw_bytes(),
+            g2: self.params.g2.to_raw_bytes(),
+            s_g2: self.params.s_g2.to_raw_bytes(),
+        };
+
+        bincode::serialize(&serializable).unwrap_or_default()
+    }
+
+    pub fn to_laconic_bytes(&self) -> Vec<u8> {
+        // Direct conversion to SerializableLaconicParams
+        let serializable = SerializableLaconicParams {
+            k: self.k as u32,
+            g0: self.params.g[0].to_raw_bytes(),
+            g2: self.params.g2.to_raw_bytes(),
+            s_g2: self.params.s_g2.to_raw_bytes(),
+        };
+
+        bincode::serialize(&serializable).unwrap_or_default()
+    }
+
+    // pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
+    //     let serializable: SerializableHalo2Params =
+    //         bincode::deserialize(bytes).map_err(|_| "Failed to deserialize Halo2Params")?;
+
+    //     // Convert the serializable format to Halo2Params
+    //     let k = serializable.k as usize;
+    //     let domain = EvaluationDomain::new(1, serializable.k);
+
+    //     // Deserialize curve points
+    //     let g0 =
+    //         G1Affine::from_raw_bytes(&serializable.g0).ok_or("Failed to deserialize G1 point")?;
+    //     let g2 =
+    //         G2Affine::from_raw_bytes(&serializable.g2).ok_or("Failed to deserialize G2 point")?;
+    //     let s_g2 =
+    //         G2Affine::from_raw_bytes(&serializable.s_g2).ok_or("Failed to deserialize G2 point")?;
+
+    //     // Create ParamsKZG
+    //     let params = ParamsKZG {
+    //         k: serializable.k,
+    //         n: 1 << serializable.k as u64,
+    //         g: vec![g0],
+    //         g_lagrange: vec![],
+    //         g2,
+    //         s_g2,
+    //     };
+
+    //     Ok(Halo2Params { k, domain, params })
+    // }
+}
+
+/// Minimal parameters needed for LaconicOT protocols
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaconicParams {
+    pub k: u32,
+    pub g0: G1Affine,   // Just the first generator point
+    pub g2: G2Affine,   // G2 generator
+    pub s_g2: G2Affine, // G2 s-value
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SerializableLaconicParams {
+    pub k: u32,
+    pub g0: Vec<u8>,
+    pub g2: Vec<u8>,
+    pub s_g2: Vec<u8>,
+}
+
+// Conversion from Halo2Params to LaconicParams
+impl From<&Halo2Params> for LaconicParams {
+    fn from(params: &Halo2Params) -> Self {
+        LaconicParams {
+            k: params.k as u32,
+            g0: params.params.g[0],
+            g2: params.params.g2,
+            s_g2: params.params.s_g2,
+        }
+    }
+}
+
+// Serialization impl
+impl From<&LaconicParams> for SerializableLaconicParams {
+    fn from(params: &LaconicParams) -> Self {
+        SerializableLaconicParams {
+            k: params.k,
+            g0: params.g0.to_raw_bytes(),
+            g2: params.g2.to_raw_bytes(),
+            s_g2: params.s_g2.to_raw_bytes(),
+        }
+    }
+}
+
+// Deserialization impl
+impl TryFrom<SerializableLaconicParams> for LaconicParams {
+    type Error = &'static str;
+
+    fn try_from(s: SerializableLaconicParams) -> Result<Self, Self::Error> {
+        let g0 = G1Affine::from_raw_bytes(&s.g0).ok_or("Failed to deserialize g0")?;
+        let g2 = G2Affine::from_raw_bytes(&s.g2).ok_or("Failed to deserialize g2")?;
+        let s_g2 = G2Affine::from_raw_bytes(&s.s_g2).ok_or("Failed to deserialize s_g2")?;
+
+        Ok(LaconicParams {
+            k: s.k,
+            g0,
+            g2,
+            s_g2,
+        })
+    }
+}
+
+impl LaconicParams {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let serializable = SerializableLaconicParams::from(self);
+        bincode::serialize(&serializable).unwrap_or_default()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
+        let serializable: SerializableLaconicParams =
+            bincode::deserialize(bytes).map_err(|_| "Failed to deserialize LaconicParams")?;
+
+        LaconicParams::try_from(serializable)
     }
 }

--- a/plain_lot/Cargo.toml
+++ b/plain_lot/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-ark-bls12-381 = "0.4.0"
-ark-ec = "0.4.2"
-ark-ff = "0.4.2"
-ark-poly = "0.4.2"
+ark-bls12-381 = { version = "0.4.0" }
+ark-ec = { version = "0.4.0" }
+ark-ff = { version = "0.4.0" }
+ark-poly = "0.4.0"
 ark-poly-commit = "0.4.0"
-ark-serialize = "0.4.2"
+ark-serialize = { version = "0.4.0" }
 ark-std = "0.4.0"
 rand = "0.8.5"
 blake3 = "1.5"

--- a/plain_lot/src/laconic_ot.rs
+++ b/plain_lot/src/laconic_ot.rs
@@ -59,7 +59,7 @@ pub struct Msg<E: Pairing> {
     pub h: [(E::G2Affine, [u8; MSG_SIZE]); 2],
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SerializableMsg {
     pub h: [(Vec<u8>, [u8; MSG_SIZE]); 2],
 }

--- a/plain_lot/src/lib.rs
+++ b/plain_lot/src/lib.rs
@@ -5,7 +5,7 @@ mod kzg_utils;
 
 mod laconic_ot;
 
-pub use laconic_ot::{Choice, Com, LaconicOTRecv, LaconicOTSender, Msg};
+pub use laconic_ot::{Choice, Com, LaconicOTRecv, LaconicOTSender, Msg, SerializableMsg};
 
 pub use kzg_utils::plain_kzg_com;
 

--- a/trinity-ts/packages/app/package.json
+++ b/trinity-ts/packages/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trinity/app",
+  "name": "@trinity_2pc/app",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/trinity-ts/packages/app/src/App.tsx
+++ b/trinity-ts/packages/app/src/App.tsx
@@ -19,6 +19,12 @@ type ComputationState =
   | "result_computed" // Computation complete
   | "error"; // Error state
 
+function booleanArrayToInteger(boolArray: Uint8Array): number {
+  return boolArray.reduce((acc, bit, index) => {
+    return acc + (bit ? 1 : 0) * Math.pow(2, index);
+  }, 0);
+}
+
 function App() {
   // State for the application
   const [trinity, setTrinity] = useState<TrinityModule | null>(null);
@@ -96,7 +102,7 @@ function App() {
 
     try {
       const garblerObj = trinity.TrinityGarbler(
-        evaluator.commitment,
+        evaluator.commitment_serialized,
         setup,
         intToUint8Array2(garblerInput),
         circuit
@@ -116,7 +122,9 @@ function App() {
 
     try {
       const computationResult = evaluator.evaluate(garbler, circuit);
-      setResult(computationResult);
+      console.log("Computation result:", computationResult);
+      const resultAsInteger = booleanArrayToInteger(computationResult);
+      setResult(resultAsInteger);
       setComputationState("result_computed");
     } catch (err) {
       setError((err as Error).toString());

--- a/trinity-ts/packages/core/README.md
+++ b/trinity-ts/packages/core/README.md
@@ -1,0 +1,3 @@
+# @trinity/core
+
+TypeScript bindings for the Trinity 2PC protocol.

--- a/trinity-ts/packages/core/package.json
+++ b/trinity-ts/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trinity/core",
+  "name": "@trinity_2pc/core",
   "version": "0.1.0",
   "description": "TypeScript bindings for Trinity 2PC protocol",
   "main": "dist/index.js",
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
-    "src/wasm/*.wasm"
+    "src/wasm/*.wasm",
+    "README.md"
   ],
   "exports": {
     ".": {

--- a/trinity-ts/packages/core/src/core.ts
+++ b/trinity-ts/packages/core/src/core.ts
@@ -29,7 +29,7 @@ export interface TrinityModule {
   ) => TrinityEvaluator;
 
   TrinityGarbler: (
-    evaluator_commitment: WasmCommitment,
+    evaluator_commitment: string,
     setup: TrinityWasmSetup,
     garbler_input: Uint8Array,
     circuit: CircuitWrapper
@@ -84,7 +84,7 @@ export async function initTrinity(): Promise<TrinityModule> {
     },
 
     TrinityGarbler: function (
-      evaluator_commitment: WasmCommitment,
+      evaluator_commitment: string,
       setup: TrinityWasmSetup,
       garbler_input: Uint8Array,
       circuit: CircuitWrapper

--- a/trinity/Cargo.toml
+++ b/trinity/Cargo.toml
@@ -16,11 +16,12 @@ serde-wasm-bindgen = "0.6"
 rand = { version = "0.8.5", features = ["getrandom"] }
 getrandom = { version = "0.2", features = ["js"] }
 mpz-garble-core = { git = "https://github.com/Meyanis95/mpz.git", branch = "feat/string_parser" }
-mpz-circuits = { git = "https://github.com/Meyanis95/mpz.git", branch = "feat/string_parser" }
+mpz-circuits = { git = "https://github.com/Meyanis95/mpz.git", branch = "feat/string_parser" , features = ["serde"]}
 mpz-core = { git = "https://github.com/Meyanis95/mpz.git", branch = "feat/string_parser" }
 itybity = "0.3.1"
 halo2_we_kzg = { path = "../halo2_lot" }
 halo2curves = { git = "https://github.com/Meyanis95/halo2curves.git", branch = "main" }
+bincode = "1.3.3"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/trinity/Cargo.toml
+++ b/trinity/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 laconic-ot = { path = "../plain_lot" }
 ark-bn254 = "0.4.0"
 ark-poly = "0.4.0"
+ark-serialize = "0.4.0"
 serde_json = "1.0.140"
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/trinity/Cargo.toml
+++ b/trinity/Cargo.toml
@@ -28,5 +28,5 @@ bincode = "1.3.3"
 crate-type = ["cdylib", "rlib"]
 
 [patch.crates-io]
-halo2curves = { git = "https://github.com/Meyanis95/halo2curves.git", branch = "main" }
+halo2curves = { git = "https://github.com/Meyanis95/halo2curves.git", branch = "main", features = ["derive_serde"] }
 

--- a/trinity/src/commit.rs
+++ b/trinity/src/commit.rs
@@ -86,7 +86,7 @@ pub enum TrinityCom {
 #[derive(Serialize, Deserialize)]
 pub enum SerializableTrinityCom {
     Plain(Vec<u8>), // Compressed G1
-    Halo2(Vec<u8>), // Whatever halo2 Com is
+    Halo2(Vec<u8>), // halo2 Com
 }
 
 impl From<TrinityCom> for SerializableTrinityCom {
@@ -98,7 +98,7 @@ impl From<TrinityCom> for SerializableTrinityCom {
                 SerializableTrinityCom::Plain(bytes)
             }
             TrinityCom::Halo2(halo2_com) => {
-                let bytes = bincode::serialize(&halo2_com).unwrap(); // works if you enabled serde
+                let bytes = bincode::serialize(&halo2_com).unwrap();
                 SerializableTrinityCom::Halo2(bytes)
             }
         }
@@ -185,7 +185,6 @@ impl TryFrom<SerializablePlainParams> for CommitmentKey<Bn254, Radix2EvaluationD
     type Error = &'static str;
 
     fn try_from(s: SerializablePlainParams) -> Result<Self, Self::Error> {
-        // Use CanonicalDeserialize
         CommitmentKey::deserialize_uncompressed(&mut &s.commitment_key_bytes[..])
             .map_err(|_| "Failed to deserialize CommitmentKey")
     }
@@ -194,10 +193,7 @@ impl TryFrom<SerializablePlainParams> for CommitmentKey<Bn254, Radix2EvaluationD
 impl TrinityParams {
     pub fn to_sender_params(&self) -> TrinitySenderParams {
         match self {
-            TrinityParams::Plain(ck) => {
-                // Just use the full commitment key for the Plain variant
-                TrinitySenderParams::Plain(ck.clone())
-            }
+            TrinityParams::Plain(ck) => TrinitySenderParams::Plain(ck.clone()),
             TrinityParams::Halo2(params) => {
                 // Extract LaconicParams from Halo2Params
                 // As the garbler doesn't need the full Halo2Params
@@ -398,12 +394,12 @@ impl<'a> TrinitySender<'a> {
         }
     }
 
-    pub fn new_from_params(params: LaconicParams, com: TrinityCom) -> Self {
-        match com {
-            TrinityCom::Plain(com) => todo!(),
-            TrinityCom::Halo2(com) => TrinitySender::Halo2(Halo2OTSender::new_from(params, com)),
-        }
-    }
+    // pub fn new_from_params(params: LaconicParams, com: TrinityCom) -> Self {
+    //     match com {
+    //         TrinityCom::Plain(com) => todo!(),
+    //         TrinityCom::Halo2(com) => TrinitySender::Halo2(Halo2OTSender::new_from(params, com)),
+    //     }
+    // }
 
     pub fn send<R: Rng>(
         &self,

--- a/trinity/src/commit.rs
+++ b/trinity/src/commit.rs
@@ -233,8 +233,12 @@ impl Trinity {
 
         match bytes[0] {
             0 => {
-                // Deserialize Plain sender params
-                todo!()
+                let ck: CommitmentKey<_, _> =
+                    CommitmentKey::deserialize_uncompressed(&mut &bytes[1..])
+                        .map_err(|_| "Failed to deserialize CommitmentKey")?;
+                Ok(Self::setup_for_garbler(TrinitySenderParams::Plain(
+                    Arc::new(ck),
+                )))
             }
             1 => {
                 // Deserialize Halo2 sender params (LaconicParams)
@@ -270,9 +274,9 @@ impl Trinity {
             TrinityInnerParams::Full(params) => TrinitySender::new(params, com),
             TrinityInnerParams::Sender(sender_params) => {
                 match (sender_params, com) {
-                    (TrinitySenderParams::Plain(_), TrinityCom::Plain(_com)) => {
+                    (TrinitySenderParams::Plain(ck), TrinityCom::Plain(com)) => {
                         // Create Plain sender directly from plain sender params
-                        todo!()
+                        TrinitySender::Plain(PlainOTSender::new(ck.as_ref(), com))
                     }
                     (TrinitySenderParams::Halo2(laconic_params), TrinityCom::Halo2(com)) => {
                         TrinitySender::Halo2(Halo2OTSender::new_from(

--- a/trinity/src/commit.rs
+++ b/trinity/src/commit.rs
@@ -83,7 +83,7 @@ pub struct Trinity {
     pub params: TrinityParams,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug)]
 pub enum TrinityMsg {
     Plain(laconic_ot::Msg<Bn254>),
     Halo2(halo2_we_kzg::Msg),

--- a/trinity/src/commit.rs
+++ b/trinity/src/commit.rs
@@ -9,6 +9,7 @@ use laconic_ot::{
     Com as PlainCom, CommitmentKey, LaconicOTRecv as PlainOTRecv, LaconicOTSender as PlainOTSender,
 };
 use rand::{rngs::OsRng, Rng};
+use serde::{Deserialize, Serialize};
 
 use std::sync::Arc;
 
@@ -49,6 +50,7 @@ impl From<TrinityChoice> for halo2_we_kzg::Choice {
     }
 }
 
+#[derive(Serialize)]
 pub enum KZGType {
     Plain,
     Halo2,
@@ -76,13 +78,12 @@ pub enum TrinitySender<'a> {
     Halo2(Halo2OTSender),
 }
 
-#[allow(dead_code)]
 pub struct Trinity {
     pub mode: KZGType,
     pub params: TrinityParams,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum TrinityMsg {
     Plain(laconic_ot::Msg<Bn254>),
     Halo2(halo2_we_kzg::Msg),

--- a/trinity/src/evaluate.rs
+++ b/trinity/src/evaluate.rs
@@ -33,7 +33,10 @@ pub fn ev_commit(
         .collect();
 
     // === Evaluator: prepare OT receiver and commitment ===
-    let ot_receiver = setup_params.trinity.create_ot_receiver::<()>(&ev_trinity);
+    let ot_receiver = setup_params
+        .trinity
+        .create_ot_receiver::<()>(&ev_trinity)
+        .expect("Error while create the ot receiver.");
     let receiver_commitment = ot_receiver.trinity_receiver.commitment();
 
     Ok(EvaluatorBundle {

--- a/trinity/src/garble.rs
+++ b/trinity/src/garble.rs
@@ -4,7 +4,6 @@ use mpz_circuits::Circuit;
 use mpz_core::Block;
 use mpz_garble_core::{Delta, GarbledCircuit, Generator, GeneratorOutput, Key, Mac};
 use rand::{rngs::StdRng, Rng};
-use serde::{Deserialize, Serialize};
 
 use crate::{
     commit::{TrinityCom, TrinityMsg},

--- a/trinity/src/garble.rs
+++ b/trinity/src/garble.rs
@@ -5,10 +5,7 @@ use mpz_core::Block;
 use mpz_garble_core::{Delta, GarbledCircuit, Generator, GeneratorOutput, Key, Mac};
 use rand::{rngs::StdRng, Rng};
 
-use crate::{
-    commit::{Trinity, TrinityCom, TrinityMsg},
-    two_pc::SetupParams,
-};
+use crate::commit::{Trinity, TrinityCom, TrinityMsg};
 
 #[derive(Clone, Debug)]
 pub struct GarbledBundle {

--- a/trinity/src/garble.rs
+++ b/trinity/src/garble.rs
@@ -4,13 +4,14 @@ use mpz_circuits::Circuit;
 use mpz_core::Block;
 use mpz_garble_core::{Delta, GarbledCircuit, Generator, GeneratorOutput, Key, Mac};
 use rand::{rngs::StdRng, Rng};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     commit::{TrinityCom, TrinityMsg},
     two_pc::SetupParams,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GarbledBundle {
     pub ciphertexts: Vec<TrinityMsg>,
     pub garbled_circuit: GarbledCircuit,

--- a/trinity/src/garble.rs
+++ b/trinity/src/garble.rs
@@ -6,7 +6,7 @@ use mpz_garble_core::{Delta, GarbledCircuit, Generator, GeneratorOutput, Key, Ma
 use rand::{rngs::StdRng, Rng};
 
 use crate::{
-    commit::{TrinityCom, TrinityMsg},
+    commit::{Trinity, TrinityCom, TrinityMsg},
     two_pc::SetupParams,
 };
 
@@ -23,7 +23,7 @@ pub fn generate_garbled_circuit(
     garbler_bits: Vec<bool>,
     rng: &mut StdRng,
     delta: Delta,
-    setup_params: &SetupParams,
+    trinity: &Trinity,
     receiver_commitment: TrinityCom,
 ) -> GarbledBundle {
     let garbler_input_size = garbler_bits.len();
@@ -44,9 +44,7 @@ pub fn generate_garbled_circuit(
     }
 
     // Prepare OT for evaluator's inputs
-    let ot_sender = setup_params
-        .trinity
-        .create_ot_sender::<()>(receiver_commitment);
+    let ot_sender = trinity.create_ot_sender::<()>(receiver_commitment);
 
     // Create and collect OT ciphertexts (ONLY for evaluator's inputs)
     // Here we need to send message by label in order for the OT receiver to choose

--- a/trinity/src/garble.rs
+++ b/trinity/src/garble.rs
@@ -11,7 +11,7 @@ use crate::{
     two_pc::SetupParams,
 };
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct GarbledBundle {
     pub ciphertexts: Vec<TrinityMsg>,
     pub garbled_circuit: GarbledCircuit,

--- a/trinity/src/lib.rs
+++ b/trinity/src/lib.rs
@@ -111,6 +111,7 @@ impl TrinityWasmSetup {
         self.params.to_sender_bytes()
     }
 
+    #[wasm_bindgen(static_method_of = TrinityWasmSetup)]
     pub fn from_sender_setup(bytes: &[u8]) -> Result<TrinityWasmSetup, JsError> {
         let params = SetupParams::from_sender_bytes(bytes)
             .map_err(|_| JsError::new("Failed to deserialize sender parameters"))?;
@@ -233,6 +234,18 @@ impl TrinityGarbler {
 
         TrinityGarbler {
             bundle: serialized_bundle,
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn bundle(&self) -> Vec<u8> {
+        self.bundle.clone()
+    }
+
+    #[wasm_bindgen(static_method_of = TrinityGarbler)]
+    pub fn from_bundle(bundle_bytes: &[u8]) -> TrinityGarbler {
+        TrinityGarbler {
+            bundle: bundle_bytes.to_vec(),
         }
     }
 }

--- a/trinity/src/two_pc.rs
+++ b/trinity/src/two_pc.rs
@@ -22,6 +22,20 @@ pub struct SetupParams {
     pub trinity: Arc<Trinity>,
 }
 
+impl SetupParams {
+    pub fn from_sender_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
+        let trinity = Trinity::from_sender_bytes(bytes)?;
+        let arc_trinity = Arc::new(trinity);
+        Ok(Self {
+            trinity: arc_trinity,
+        })
+    }
+
+    pub fn to_sender_bytes(&self) -> Vec<u8> {
+        self.trinity.to_sender_bytes()
+    }
+}
+
 pub fn setup(mode: KZGType) -> SetupParams {
     let trinity = Arc::new(Trinity::setup(mode, MSG_SIZE));
 

--- a/trinity/src/two_pc.rs
+++ b/trinity/src/two_pc.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use serde::Serialize;
+
 use crate::commit::{KZGType, Trinity};
 
 const MSG_SIZE: usize = 16;

--- a/trinity/src/two_pc.rs
+++ b/trinity/src/two_pc.rs
@@ -66,6 +66,7 @@ mod tests {
         )
         .unwrap();
         let setup_bundle = setup(KZGType::Plain);
+        let trinity = setup_bundle.clone().trinity;
 
         let garbler_input = [6u16];
         let garbler_bits = garbler_input.into_iter_lsb0().collect::<Vec<bool>>();
@@ -84,7 +85,7 @@ mod tests {
             garbler_bits,
             &mut rng,
             delta,
-            &setup_bundle,
+            &trinity,
             evaluator_commitment.receiver_commitment,
         );
 
@@ -113,6 +114,7 @@ mod tests {
         )
         .unwrap();
         let setup_bundle = setup(KZGType::Halo2);
+        let trinity = setup_bundle.clone().trinity;
 
         let garbler_input = [6u16];
         let garbler_bits = garbler_input.into_iter_lsb0().collect::<Vec<bool>>();
@@ -131,7 +133,7 @@ mod tests {
             garbler_bits,
             &mut rng,
             delta,
-            &setup_bundle,
+            &trinity,
             evaluator_commitment.receiver_commitment,
         );
 

--- a/trinity/src/two_pc.rs
+++ b/trinity/src/two_pc.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use serde::Serialize;
-
 use crate::commit::{KZGType, Trinity};
 
 const MSG_SIZE: usize = 16;


### PR DESCRIPTION
**Add serialization strategy for running Trinity over socket communication**

This PR includes the changes needed to run the Trinity protocol between two clients using socket messaging, as in the [mpc-hello repo](https://github.com/voltrevo/mpc-hello).

- Added serialization for: `Msg`, `Com`, `GarblerBundle`, `SetupParams`
- Refactored the core TypeScript library
- Published the updated core library to npm